### PR TITLE
Added rpc.Provider interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 
 # builds:
 .builds
-solana_exporter
+/solana_exporter

--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 type solanaCollector struct {
-	rpcClient *rpc.Client
+	rpcClient rpc.Provider
 
 	totalValidatorsDesc     *prometheus.Desc
 	validatorActivatedStake *prometheus.Desc
@@ -35,9 +35,9 @@ type solanaCollector struct {
 	solanaVersion           *prometheus.Desc
 }
 
-func NewSolanaCollector(rpcAddr string) *solanaCollector {
+func createSolanaCollector(provider rpc.Provider) *solanaCollector {
 	return &solanaCollector{
-		rpcClient: rpc.NewRPCClient(rpcAddr),
+		rpcClient: provider,
 		totalValidatorsDesc: prometheus.NewDesc(
 			"solana_active_validators",
 			"Total number of active validators by state",
@@ -63,6 +63,10 @@ func NewSolanaCollector(rpcAddr string) *solanaCollector {
 			"Node version of solana",
 			[]string{"version"}, nil),
 	}
+}
+
+func NewSolanaCollector(rpcAddr string) *solanaCollector {
+	return createSolanaCollector(rpc.NewRPCClient(rpcAddr))
 }
 
 func (c *solanaCollector) Describe(ch chan<- *prometheus.Desc) {

--- a/cmd/solana_exporter/slots.go
+++ b/cmd/solana_exporter/slots.go
@@ -164,7 +164,7 @@ func getEpochBounds(info *rpc.EpochInfo) (int64, int64, int64) {
 	return info.Epoch, firstSlot, lastSlot
 }
 
-func updateCounters(c *rpc.Client, epoch, firstSlot int64, lastSlotOpt *int64) (int64, error) {
+func updateCounters(c rpc.Provider, epoch, firstSlot int64, lastSlotOpt *int64) (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -35,11 +35,34 @@ type (
 	Commitment string
 )
 
+// Provider is an interface that defines the methods required to interact with the Solana blockchain.
+// It provides methods to retrieve block production information, epoch info, slot info, vote accounts, and node version.
 type Provider interface {
+
+	// GetBlockProduction retrieves the block production information for the specified slot range.
+	// The method takes a context for cancellation, and pointers to the first and last slots of the range.
+	// It returns a BlockProduction struct containing the block production details, or an error if the operation fails.
 	GetBlockProduction(ctx context.Context, firstSlot *int64, lastSlot *int64) (BlockProduction, error)
+
+	// GetEpochInfo retrieves the information regarding the current epoch.
+	// The method takes a context for cancellation and a commitment level to specify the desired state.
+	// It returns a pointer to an EpochInfo struct containing the epoch details, or an error if the operation fails.
 	GetEpochInfo(ctx context.Context, commitment Commitment) (*EpochInfo, error)
+
+	// GetSlot retrieves the current slot number.
+	// The method takes a context for cancellation.
+	// It returns the current slot number as an int64, or an error if the operation fails.
 	GetSlot(ctx context.Context) (int64, error)
+
+	// GetVoteAccounts retrieves the vote accounts information.
+	// The method takes a context for cancellation and a slice of parameters to filter the vote accounts.
+	// It returns a pointer to a GetVoteAccountsResponse struct containing the vote accounts details,
+	// or an error if the operation fails.
 	GetVoteAccounts(ctx context.Context, params []interface{}) (*GetVoteAccountsResponse, error)
+
+	// GetVersion retrieves the version of the Solana node.
+	// The method takes a context for cancellation.
+	// It returns a pointer to a string containing the version information, or an error if the operation fails.
 	GetVersion(ctx context.Context) (*string, error)
 }
 

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -35,6 +35,14 @@ type (
 	Commitment string
 )
 
+type Provider interface {
+	GetBlockProduction(ctx context.Context, firstSlot *int64, lastSlot *int64) (BlockProduction, error)
+	GetEpochInfo(ctx context.Context, commitment Commitment) (*EpochInfo, error)
+	GetSlot(ctx context.Context) (int64, error)
+	GetVoteAccounts(ctx context.Context, params []interface{}) (*GetVoteAccountsResponse, error)
+	GetVersion(ctx context.Context) (*string, error)
+}
+
 func (c Commitment) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{"commitment": string(c)})
 }


### PR DESCRIPTION
By adding this interface it allows for the creation of a `mockRPCClient` (still to come) which can be used to feed in test data