### PR TITLE
WIP: Fee rewards!!!

### DIFF
--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -276,15 +276,20 @@ func main() {
 	)
 	if *balanceAddresses != "" {
 		balAddresses = strings.Split(*balanceAddresses, ",")
+		klog.Infof("Monitoring balances for %v", balAddresses)
 	}
 	if *leaderSlotAddresses != "" {
 		lsAddresses = strings.Split(*leaderSlotAddresses, ",")
+		klog.Infof("Monitoring leader-slot by epoch for %v", lsAddresses)
+
 	}
 	if *inflationRewardAddresses != "" {
 		irAddresses = strings.Split(*inflationRewardAddresses, ",")
+		klog.Infof("Monitoring inflation reward by epoch for %v", irAddresses)
 	}
 	if *feeRewardAddresses != "" {
 		frAddresses = strings.Split(*feeRewardAddresses, ",")
+		klog.Infof("Monitoring fee reward by epoch for %v", frAddresses)
 	}
 
 	collector := NewSolanaCollector(*rpcAddr, balAddresses, lsAddresses, irAddresses, frAddresses)

--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -138,7 +138,7 @@ func (c *solanaCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *solanaCollector) collectVoteAccounts(ctx context.Context, ch chan<- prometheus.Metric) {
-	voteAccounts, err := c.rpcClient.GetVoteAccounts(ctx, rpc.CommitmentProcessed, votePubkey)
+	voteAccounts, err := c.rpcClient.GetVoteAccounts(ctx, rpc.CommitmentConfirmed, votePubkey)
 	if err != nil {
 		ch <- prometheus.NewInvalidMetric(c.totalValidatorsDesc, err)
 		ch <- prometheus.NewInvalidMetric(c.validatorActivatedStake, err)
@@ -217,7 +217,7 @@ func (c *solanaCollector) collectBalances(ctx context.Context, ch chan<- prometh
 func fetchBalances(ctx context.Context, client rpc.Provider, addresses []string) (map[string]float64, error) {
 	balances := make(map[string]float64)
 	for _, address := range addresses {
-		balance, err := client.GetBalance(ctx, address)
+		balance, err := client.GetBalance(ctx, rpc.CommitmentConfirmed, address)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/solana_exporter/exporter_test.go
+++ b/cmd/solana_exporter/exporter_test.go
@@ -47,7 +47,7 @@ var (
 	identityVotes   = map[string]string{"aaa": "AAA", "bbb": "BBB", "ccc": "CCC"}
 	nv              = len(identities)
 	staticEpochInfo = rpc.EpochInfo{
-		AbsoluteSlot:     166598,
+		AbsoluteSlot:     166599,
 		BlockHeight:      166500,
 		Epoch:            27,
 		SlotIndex:        2790,
@@ -70,12 +70,9 @@ var (
 	staticVoteAccounts = rpc.VoteAccounts{
 		Current: []rpc.VoteAccount{
 			{
-				ActivatedStake: 42,
-				Commission:     0,
-				EpochCredits: [][]int{
-					{1, 64, 0},
-					{2, 192, 64},
-				},
+				ActivatedStake:   42,
+				Commission:       0,
+				EpochCredits:     [][]int{{1, 64, 0}, {2, 192, 64}},
 				EpochVoteAccount: true,
 				LastVote:         147,
 				NodePubkey:       "bbb",
@@ -83,12 +80,9 @@ var (
 				VotePubkey:       "BBB",
 			},
 			{
-				ActivatedStake: 43,
-				Commission:     1,
-				EpochCredits: [][]int{
-					{2, 65, 1},
-					{3, 193, 65},
-				},
+				ActivatedStake:   43,
+				Commission:       1,
+				EpochCredits:     [][]int{{2, 65, 1}, {3, 193, 65}},
 				EpochVoteAccount: true,
 				LastVote:         148,
 				NodePubkey:       "ccc",
@@ -98,12 +92,9 @@ var (
 		},
 		Delinquent: []rpc.VoteAccount{
 			{
-				ActivatedStake: 49,
-				Commission:     2,
-				EpochCredits: [][]int{
-					{10, 594, 6},
-					{9, 98, 4},
-				},
+				ActivatedStake:   49,
+				Commission:       2,
+				EpochCredits:     [][]int{{10, 594, 6}, {9, 98, 4}},
 				EpochVoteAccount: true,
 				LastVote:         92,
 				NodePubkey:       "aaa",
@@ -111,6 +102,9 @@ var (
 				VotePubkey:       "AAA",
 			},
 		},
+	}
+	staticLeaderSchedule = map[string][]int64{
+		"aaa": {0, 3, 6, 9, 12}, "bbb": {1, 4, 7, 10, 13}, "ccc": {2, 5, 8, 11, 14},
 	}
 )
 
@@ -164,7 +158,7 @@ func (c *staticRPCClient) GetInflationReward(
 func (c *staticRPCClient) GetLeaderSchedule(
 	ctx context.Context, commitment rpc.Commitment, slot int64,
 ) (map[string][]int64, error) {
-	return nil, nil
+	return staticLeaderSchedule, nil
 }
 
 //goland:noinspection GoUnusedParameter

--- a/cmd/solana_exporter/exporter_test.go
+++ b/cmd/solana_exporter/exporter_test.go
@@ -160,6 +160,18 @@ func (c *staticRPCClient) GetInflationReward(
 	return staticInflationRewards, nil
 }
 
+//goland:noinspection GoUnusedParameter
+func (c *staticRPCClient) GetLeaderSchedule(
+	ctx context.Context, commitment rpc.Commitment, slot int64,
+) (map[string][]int64, error) {
+	return nil, nil
+}
+
+//goland:noinspection GoUnusedParameter
+func (c *staticRPCClient) GetBlock(ctx context.Context, commitment rpc.Commitment, slot int64) (*rpc.Block, error) {
+	return nil, nil
+}
+
 /*
 ===== DYNAMIC CLIENT =====:
 */
@@ -341,6 +353,18 @@ func (c *dynamicRPCClient) GetInflationReward(
 	return staticInflationRewards, nil
 }
 
+//goland:noinspection GoUnusedParameter
+func (c *dynamicRPCClient) GetLeaderSchedule(
+	ctx context.Context, commitment rpc.Commitment, slot int64,
+) (map[string][]int64, error) {
+	return nil, nil
+}
+
+//goland:noinspection GoUnusedParameter
+func (c *dynamicRPCClient) GetBlock(ctx context.Context, commitment rpc.Commitment, slot int64) (*rpc.Block, error) {
+	return nil, nil
+}
+
 /*
 ===== OTHER TEST UTILITIES =====:
 */
@@ -376,7 +400,9 @@ func runCollectionTests(t *testing.T, collector prometheus.Collector, testCases 
 }
 
 func TestSolanaCollector_Collect_Static(t *testing.T) {
-	collector := createSolanaCollector(&staticRPCClient{}, slotPacerSchedule, identities, []string{}, votekeys)
+	collector := createSolanaCollector(
+		&staticRPCClient{}, slotPacerSchedule, identities, []string{}, votekeys, identities,
+	)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 
 	testCases := []collectionTest{
@@ -454,7 +480,7 @@ solana_account_balance{address="ccc"} 3
 
 func TestSolanaCollector_Collect_Dynamic(t *testing.T) {
 	client := newDynamicRPCClient()
-	collector := createSolanaCollector(client, slotPacerSchedule, identities, []string{}, votekeys)
+	collector := createSolanaCollector(client, slotPacerSchedule, identities, []string{}, votekeys, identities)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 
 	// start off by testing initial state:

--- a/cmd/solana_exporter/exporter_test.go
+++ b/cmd/solana_exporter/exporter_test.go
@@ -124,7 +124,7 @@ func (c *staticRPCClient) GetEpochInfo(ctx context.Context, commitment rpc.Commi
 }
 
 //goland:noinspection GoUnusedParameter
-func (c *staticRPCClient) GetSlot(ctx context.Context) (int64, error) {
+func (c *staticRPCClient) GetSlot(ctx context.Context, commitment rpc.Commitment) (int64, error) {
 	return staticEpochInfo.AbsoluteSlot, nil
 }
 
@@ -143,19 +143,19 @@ func (c *staticRPCClient) GetVoteAccounts(
 
 //goland:noinspection GoUnusedParameter
 func (c *staticRPCClient) GetBlockProduction(
-	ctx context.Context, identity *string, firstSlot *int64, lastSlot *int64,
+	ctx context.Context, commitment rpc.Commitment, identity *string, firstSlot *int64, lastSlot *int64,
 ) (*rpc.BlockProduction, error) {
 	return &staticBlockProduction, nil
 }
 
 //goland:noinspection GoUnusedParameter
-func (c *staticRPCClient) GetBalance(ctx context.Context, address string) (float64, error) {
+func (c *staticRPCClient) GetBalance(ctx context.Context, commitment rpc.Commitment, address string) (float64, error) {
 	return balances[address], nil
 }
 
 //goland:noinspection GoUnusedParameter
 func (c *staticRPCClient) GetInflationReward(
-	ctx context.Context, addresses []string, commitment rpc.Commitment, epoch *int64, minContextSlot *int64,
+	ctx context.Context, commitment rpc.Commitment, addresses []string, epoch *int64, minContextSlot *int64,
 ) ([]rpc.InflationReward, error) {
 	return staticInflationRewards, nil
 }
@@ -271,7 +271,7 @@ func (c *dynamicRPCClient) GetEpochInfo(ctx context.Context, commitment rpc.Comm
 }
 
 //goland:noinspection GoUnusedParameter
-func (c *dynamicRPCClient) GetSlot(ctx context.Context) (int64, error) {
+func (c *dynamicRPCClient) GetSlot(ctx context.Context, commitment rpc.Commitment) (int64, error) {
 	return int64(c.Slot), nil
 }
 
@@ -308,7 +308,7 @@ func (c *dynamicRPCClient) GetVoteAccounts(
 
 //goland:noinspection GoUnusedParameter
 func (c *dynamicRPCClient) GetBlockProduction(
-	ctx context.Context, identity *string, firstSlot *int64, lastSlot *int64,
+	ctx context.Context, commitment rpc.Commitment, identity *string, firstSlot *int64, lastSlot *int64,
 ) (*rpc.BlockProduction, error) {
 	byIdentity := make(map[string]rpc.HostProduction)
 	for _, identity := range identities {
@@ -330,13 +330,13 @@ func (c *dynamicRPCClient) GetBlockProduction(
 }
 
 //goland:noinspection GoUnusedParameter
-func (c *dynamicRPCClient) GetBalance(ctx context.Context, address string) (float64, error) {
+func (c *dynamicRPCClient) GetBalance(ctx context.Context, client rpc.Commitment, address string) (float64, error) {
 	return balances[address], nil
 }
 
 //goland:noinspection GoUnusedParameter
 func (c *dynamicRPCClient) GetInflationReward(
-	ctx context.Context, addresses []string, commitment rpc.Commitment, epoch *int64, minContextSlot *int64,
+	ctx context.Context, commitment rpc.Commitment, addresses []string, epoch *int64, minContextSlot *int64,
 ) ([]rpc.InflationReward, error) {
 	return staticInflationRewards, nil
 }

--- a/cmd/solana_exporter/slots.go
+++ b/cmd/solana_exporter/slots.go
@@ -117,7 +117,7 @@ func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
 			<-ticker.C
 
 			ctx_, cancel := context.WithTimeout(ctx, httpTimeout)
-			epochInfo, err := c.client.GetEpochInfo(ctx_, rpc.CommitmentFinalized)
+			epochInfo, err := c.client.GetEpochInfo(ctx_, rpc.CommitmentConfirmed)
 			if err != nil {
 				klog.Warningf("Failed to get epoch info, bailing out: %v", err)
 			}
@@ -236,7 +236,7 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 	// fetch block production:
 	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
 	defer cancel()
-	blockProduction, err := c.client.GetBlockProduction(ctx, nil, &startSlot, &endSlot)
+	blockProduction, err := c.client.GetBlockProduction(ctx, rpc.CommitmentConfirmed, nil, &startSlot, &endSlot)
 	if err != nil {
 		klog.Warningf("Failed to get block production, bailing out: %v", err)
 	}
@@ -278,7 +278,7 @@ func (c *SlotWatcher) fetchAndEmitInflationRewards(ctx context.Context, epoch in
 	defer cancel()
 
 	rewardInfos, err := c.client.GetInflationReward(
-		ctx, c.inflationRewardAddresses, rpc.CommitmentFinalized, &epoch, nil,
+		ctx, rpc.CommitmentConfirmed, c.inflationRewardAddresses, &epoch, nil,
 	)
 	if err != nil {
 		return err

--- a/cmd/solana_exporter/slots.go
+++ b/cmd/solana_exporter/slots.go
@@ -130,15 +130,17 @@ func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
 			<-ticker.C
 
 			ctx_, cancel := context.WithTimeout(ctx, httpTimeout)
-			epochInfo, err := c.client.GetEpochInfo(ctx_, rpc.CommitmentConfirmed)
-			if err != nil {
-				klog.Warningf("Failed to get epoch info, bailing out: %v", err)
-			}
+			// TODO: separate fee-rewards watching from general slot watching, such that general slot watching commitment level can be dropped to confirmed
+			epochInfo, err := c.client.GetEpochInfo(ctx_, rpc.CommitmentFinalized)
 			cancel()
+			if err != nil {
+				klog.Errorf("Failed to get epoch info, bailing out: %v", err)
+				continue
+			}
 
 			// if we are running for the first time, then we need to set our tracking numbers:
 			if c.currentEpoch == 0 {
-				c.trackEpoch(epochInfo)
+				c.trackEpoch(ctx, epochInfo)
 			}
 
 			totalTransactionsTotal.Set(float64(epochInfo.TransactionCount))
@@ -163,14 +165,15 @@ func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
 			}
 
 			// update block production metrics up until the current slot:
-			c.fetchAndEmitBlockProduction(ctx, epochInfo.AbsoluteSlot)
+			c.moveSlotWatermark(ctx, epochInfo.AbsoluteSlot)
 		}
 	}
 }
 
 // trackEpoch takes in a new rpc.EpochInfo and sets the SlotWatcher tracking metrics accordingly,
 // and updates the prometheus gauges associated with those metrics.
-func (c *SlotWatcher) trackEpoch(epoch *rpc.EpochInfo) {
+func (c *SlotWatcher) trackEpoch(ctx context.Context, epoch *rpc.EpochInfo) {
+	klog.Infof("Tracking epoch %v (from %v)", epoch.Epoch, c.currentEpoch)
 	firstSlot, lastSlot := getEpochBounds(epoch)
 	// if we haven't yet set c.currentEpoch, that (hopefully) means this is the initial setup,
 	// and so we can simply store the tracking numbers
@@ -207,16 +210,29 @@ func (c *SlotWatcher) trackEpoch(epoch *rpc.EpochInfo) {
 	}
 
 	// emit epoch bounds:
+	klog.Infof("Emitting epoch bounds: %v (slots %v -> %v)", c.currentEpoch, c.firstSlot, c.lastSlot)
 	currentEpochNumber.Set(float64(c.currentEpoch))
 	epochFirstSlot.Set(float64(c.firstSlot))
 	epochLastSlot.Set(float64(c.lastSlot))
+
+	// update leader schedule:
+	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+	klog.Infof("Updating leader schedule for epoch %v ...", c.currentEpoch)
+	leaderSchedule, err := GetTrimmedLeaderSchedule(
+		ctx, c.client, c.feeRewardAddresses, epoch.AbsoluteSlot, c.firstSlot,
+	)
+	if err != nil {
+		klog.Errorf("Failed to get trimmed leader schedule, bailing out: %v", err)
+	}
+	c.leaderSchedule = leaderSchedule
 }
 
 // closeCurrentEpoch is called when an epoch change-over happens, and we need to make sure we track the last
 // remaining slots in the "current" epoch before we start tracking the new one.
 func (c *SlotWatcher) closeCurrentEpoch(ctx context.Context, newEpoch *rpc.EpochInfo) {
-	c.fetchAndEmitBlockProduction(ctx, c.lastSlot)
-	c.trackEpoch(newEpoch)
+	c.moveSlotWatermark(ctx, c.lastSlot)
+	c.trackEpoch(ctx, newEpoch)
 }
 
 // checkValidSlotRange makes sure that the slot range we are going to query is within the current epoch we are tracking.
@@ -234,6 +250,13 @@ func (c *SlotWatcher) checkValidSlotRange(from, to int64) error {
 	return nil
 }
 
+// moveSlotWatermark performs all the slot-watching tasks required to move the slotWatermark to the provided 'to' slot.
+func (c *SlotWatcher) moveSlotWatermark(ctx context.Context, to int64) {
+	c.fetchAndEmitBlockProduction(ctx, to)
+	c.fetchAndEmitFeeRewards(ctx, to)
+	c.slotWatermark = to
+}
+
 // fetchAndEmitBlockProduction fetches block production up to the provided endSlot, emits the prometheus metrics,
 // and updates the SlotWatcher.slotWatermark accordingly
 func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot int64) {
@@ -249,9 +272,10 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 	// fetch block production:
 	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
 	defer cancel()
-	blockProduction, err := c.client.GetBlockProduction(ctx, rpc.CommitmentConfirmed, nil, &startSlot, &endSlot)
+	blockProduction, err := c.client.GetBlockProduction(ctx, rpc.CommitmentFinalized, nil, &startSlot, &endSlot)
 	if err != nil {
-		klog.Warningf("Failed to get block production, bailing out: %v", err)
+		klog.Errorf("Failed to get block production, bailing out: %v", err)
+		return
 	}
 
 	// emit the metrics:
@@ -270,8 +294,61 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 	}
 
 	klog.Infof("Fetched block production in [%v -> %v]", startSlot, endSlot)
-	// update the slot watermark:
-	c.slotWatermark = endSlot
+}
+
+// fetchAndEmitFeeRewards fetches and emits all the fee rewards for the tracked addresses between the
+// slotWatermark and endSlot
+func (c *SlotWatcher) fetchAndEmitFeeRewards(ctx context.Context, endSlot int64) {
+	startSlot := c.slotWatermark + 1
+	klog.Infof("Fetching fee rewards in [%v -> %v]", startSlot, endSlot)
+
+	if err := c.checkValidSlotRange(startSlot, endSlot); err != nil {
+		klog.Fatalf("invalid slot range: %v", err)
+	}
+	scheduleToFetch := SelectFromSchedule(c.leaderSchedule, startSlot, endSlot)
+	for identity, leaderSlots := range scheduleToFetch {
+		if len(leaderSlots) == 0 {
+			continue
+		}
+
+		klog.Infof("Fetching fee rewards for %v in [%v -> %v]: %v ...", identity, startSlot, endSlot, leaderSlots)
+		for _, slot := range leaderSlots {
+			ctx, cancel := context.WithTimeout(ctx, httpTimeout)
+			err := c.fetchAndEmitSingleFeeReward(ctx, identity, c.currentEpoch, slot)
+			cancel()
+			if err != nil {
+				klog.Errorf("Failed to fetch fee rewards for %v at %v: %v", identity, slot, err)
+			}
+		}
+	}
+
+	klog.Infof("Fetched fee rewards in [%v -> %v]", startSlot, endSlot)
+}
+
+// fetchAndEmitSingleFeeReward fetches and emits the fee reward for a single block.
+func (c *SlotWatcher) fetchAndEmitSingleFeeReward(
+	ctx context.Context, identity string, epoch int64, slot int64,
+) error {
+	block, err := c.client.GetBlock(ctx, rpc.CommitmentConfirmed, slot)
+	if err != nil {
+		return err
+	}
+
+	for _, reward := range block.Rewards {
+		if reward.RewardType == "fee" {
+			// make sure we haven't made a logic issue or something:
+			assertf(
+				reward.Pubkey == identity,
+				"fetching fee reward for %v but got fee reward for %v",
+				identity,
+				reward.Pubkey,
+			)
+			amount := float64(reward.Lamports) / float64(rpc.LamportsInSol)
+			feeRewards.WithLabelValues(identity, toString(epoch)).Add(amount)
+		}
+	}
+
+	return nil
 }
 
 // getEpochBounds returns the first slot and last slot within an [inclusive] Epoch
@@ -301,30 +378,5 @@ func (c *SlotWatcher) fetchAndEmitInflationRewards(ctx context.Context, epoch in
 		inflationRewards.WithLabelValues(address, toString(epoch)).Set(reward)
 	}
 	klog.Infof("Fetched inflation reward for epoch %v.", epoch)
-	return nil
-}
-
-func (c *SlotWatcher) fetchAndEmitFeeReward(
-	ctx context.Context, identity string, epoch int64, slot int64,
-) error {
-	block, err := c.client.GetBlock(ctx, rpc.CommitmentConfirmed, slot)
-	if err != nil {
-		return err
-	}
-
-	for _, reward := range block.Rewards {
-		if reward.RewardType == "fee" {
-			// make sure we haven't made a logic issue or something:
-			assertf(
-				reward.Pubkey == identity,
-				"fetching fee reward for %v but got fee reward for %v",
-				identity,
-				reward.Pubkey,
-			)
-			amount := float64(reward.Lamports) / float64(rpc.LamportsInSol)
-			feeRewards.WithLabelValues(identity, toString(epoch)).Add(amount)
-		}
-	}
-
 	return nil
 }

--- a/cmd/solana_exporter/slots_test.go
+++ b/cmd/solana_exporter/slots_test.go
@@ -92,7 +92,9 @@ func TestSolanaCollector_WatchSlots_Static(t *testing.T) {
 	leaderSlotsTotal.Reset()
 	leaderSlotsByEpoch.Reset()
 
-	collector := createSolanaCollector(&staticRPCClient{}, 100*time.Millisecond, identities, []string{}, votekeys)
+	collector := createSolanaCollector(
+		&staticRPCClient{}, 100*time.Millisecond, identities, []string{}, votekeys, identities,
+	)
 	watcher := NewCollectorSlotWatcher(collector)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -161,7 +163,7 @@ func TestSolanaCollector_WatchSlots_Dynamic(t *testing.T) {
 
 	// create clients:
 	client := newDynamicRPCClient()
-	collector := createSolanaCollector(client, 300*time.Millisecond, identities, []string{}, votekeys)
+	collector := createSolanaCollector(client, 300*time.Millisecond, identities, []string{}, votekeys, identities)
 	watcher := NewCollectorSlotWatcher(collector)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 

--- a/cmd/solana_exporter/utils.go
+++ b/cmd/solana_exporter/utils.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"github.com/asymmetric-research/solana_exporter/pkg/rpc"
 	"k8s.io/klog/v2"
 )
 
@@ -11,6 +13,50 @@ func assertf(condition bool, format string, args ...any) {
 	}
 }
 
+// toString is just a simple utility function for converting int -> string
 func toString(i int64) string {
 	return fmt.Sprintf("%v", i)
+}
+
+// SelectFromSchedule takes a leader-schedule and returns a trimmed leader-schedule
+// containing only the slots within the provided range
+func SelectFromSchedule(schedule map[string][]int64, startSlot, endSlot int64) map[string][]int64 {
+	selected := make(map[string][]int64)
+	for key, values := range schedule {
+		var selectedValues []int64
+		for _, value := range values {
+			if value >= startSlot && value <= endSlot {
+				selectedValues = append(selectedValues, value)
+			}
+		}
+		selected[key] = selectedValues
+	}
+	return selected
+}
+
+// GetTrimmedLeaderSchedule fetches the leader schedule, but only for the validators we are interested in.
+// Additionally, it adjusts the leader schedule to the current epoch offset.
+func GetTrimmedLeaderSchedule(
+	ctx context.Context, client rpc.Provider, identities []string, slot, epochFirstSlot int64,
+) (map[string][]int64, error) {
+	leaderSchedule, err := client.GetLeaderSchedule(ctx, rpc.CommitmentConfirmed, slot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get leader schedule: %w", err)
+	}
+
+	trimmedLeaderSchedule := make(map[string][]int64)
+	for _, id := range identities {
+		if leaderSlots, ok := leaderSchedule[id]; ok {
+			// when you fetch the leader schedule, it gives you slot indexes, we want absolute slots:
+			absoluteSlots := make([]int64, len(leaderSlots))
+			for i, slotIndex := range leaderSlots {
+				absoluteSlots[i] = slotIndex + epochFirstSlot
+			}
+			trimmedLeaderSchedule[id] = absoluteSlots
+		} else {
+			klog.Warningf("failed to find leader slots for %v", id)
+		}
+	}
+
+	return trimmedLeaderSchedule, nil
 }

--- a/cmd/solana_exporter/utils.go
+++ b/cmd/solana_exporter/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"k8s.io/klog/v2"
 )
 
@@ -8,4 +9,8 @@ func assertf(condition bool, format string, args ...any) {
 	if !condition {
 		klog.Fatalf(format, args...)
 	}
+}
+
+func toString(i int64) string {
+	return fmt.Sprintf("%v", i)
 }

--- a/cmd/solana_exporter/utils_test.go
+++ b/cmd/solana_exporter/utils_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSelectFromSchedule(t *testing.T) {
+	selected := SelectFromSchedule(staticLeaderSchedule, 5, 10)
+	assert.Equal(t,
+		map[string][]int64{"aaa": {6, 9}, "bbb": {7, 10}, "ccc": {5, 8}},
+		selected,
+	)
+}
+
+func TestGetTrimmedLeaderSchedule(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	schedule, err := GetTrimmedLeaderSchedule(ctx, &staticRPCClient{}, []string{"aaa", "bbb"}, 10, 10)
+	assert.NoError(t, err)
+
+	assert.Equal(t, map[string][]int64{"aaa": {10, 13, 16, 19, 22}, "bbb": {11, 14, 17, 20, 23}}, schedule)
+}

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -71,6 +71,10 @@ type Provider interface {
 	GetInflationReward(
 		ctx context.Context, commitment Commitment, addresses []string, epoch *int64, minContextSlot *int64,
 	) ([]InflationReward, error)
+
+	GetLeaderSchedule(ctx context.Context, commitment Commitment, slot int64) (map[string][]int64, error)
+
+	GetBlock(ctx context.Context, commitment Commitment, slot int64) (*Block, error)
 }
 
 func (c Commitment) MarshalJSON() ([]byte, error) {
@@ -259,10 +263,10 @@ func (c *Client) GetInflationReward(
 
 // GetLeaderSchedule returns the leader schedule for an epoch.
 // See API docs: https://solana.com/docs/rpc/http/getleaderschedule
-func (c *Client) GetLeaderSchedule(ctx context.Context, commitment Commitment) (map[string][]int64, error) {
+func (c *Client) GetLeaderSchedule(ctx context.Context, commitment Commitment, slot int64) (map[string][]int64, error) {
 	config := map[string]any{"commitment": string(commitment)}
 	var resp response[map[string][]int64]
-	if err := c.getResponse(ctx, "getLeaderSchedule", []any{nil, config}, &resp); err != nil {
+	if err := c.getResponse(ctx, "getLeaderSchedule", []any{slot, config}, &resp); err != nil {
 		return nil, err
 	}
 	return resp.Result, nil

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -138,6 +138,8 @@ func (c *Client) getResponse(ctx context.Context, method string, params []any, r
 	return nil
 }
 
+// GetEpochInfo returns information about the current epoch.
+// See API docs: https://solana.com/docs/rpc/http/getepochinfo
 func (c *Client) GetEpochInfo(ctx context.Context, commitment Commitment) (*EpochInfo, error) {
 	var resp response[EpochInfo]
 	if err := c.getResponse(ctx, "getEpochInfo", []any{commitment}, &resp); err != nil {
@@ -146,6 +148,8 @@ func (c *Client) GetEpochInfo(ctx context.Context, commitment Commitment) (*Epoc
 	return &resp.Result, nil
 }
 
+// GetVoteAccounts returns the account info and associated stake for all the voting accounts in the current bank.
+// See API docs: https://solana.com/docs/rpc/http/getvoteaccounts
 func (c *Client) GetVoteAccounts(
 	ctx context.Context, commitment Commitment, votePubkey *string,
 ) (*VoteAccounts, error) {
@@ -162,6 +166,8 @@ func (c *Client) GetVoteAccounts(
 	return &resp.Result, nil
 }
 
+// GetVersion returns the current Solana version running on the node.
+// See API docs: https://solana.com/docs/rpc/http/getversion
 func (c *Client) GetVersion(ctx context.Context) (string, error) {
 	var resp response[struct {
 		Version string `json:"solana-core"`
@@ -172,6 +178,8 @@ func (c *Client) GetVersion(ctx context.Context) (string, error) {
 	return resp.Result.Version, nil
 }
 
+// GetSlot returns the slot that has reached the given or default commitment level.
+// See API docs: https://solana.com/docs/rpc/http/getslot
 func (c *Client) GetSlot(ctx context.Context) (int64, error) {
 	var resp response[int64]
 	if err := c.getResponse(ctx, "getSlot", []any{}, &resp); err != nil {
@@ -180,6 +188,8 @@ func (c *Client) GetSlot(ctx context.Context) (int64, error) {
 	return resp.Result, nil
 }
 
+// GetBlockProduction returns recent block production information from the current or previous epoch.
+// See API docs: https://solana.com/docs/rpc/http/getblockproduction
 func (c *Client) GetBlockProduction(
 	ctx context.Context, identity *string, firstSlot *int64, lastSlot *int64,
 ) (*BlockProduction, error) {
@@ -219,6 +229,8 @@ func (c *Client) GetBlockProduction(
 	return &resp.Result.Value, nil
 }
 
+// GetBalance returns the lamport balance of the account of provided pubkey.
+// See API docs:https://solana.com/docs/rpc/http/getbalance
 func (c *Client) GetBalance(ctx context.Context, address string) (float64, error) {
 	var resp response[contextualResult[int64]]
 	if err := c.getResponse(ctx, "getBalance", []any{address}, &resp); err != nil {
@@ -227,6 +239,8 @@ func (c *Client) GetBalance(ctx context.Context, address string) (float64, error
 	return float64(resp.Result.Value) / float64(LamportsInSol), nil
 }
 
+// GetInflationReward returns the inflation / staking reward for a list of addresses for an epoch.
+// See API docs: https://solana.com/docs/rpc/http/getinflationreward
 func (c *Client) GetInflationReward(
 	ctx context.Context, addresses []string, commitment Commitment, epoch *int64, minContextSlot *int64,
 ) ([]InflationReward, error) {
@@ -241,6 +255,19 @@ func (c *Client) GetInflationReward(
 
 	var resp response[[]InflationReward]
 	if err := c.getResponse(ctx, "getInflationReward", []any{addresses, config}, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// GetLeaderSchedule returns the leader schedule for an epoch.
+// See API docs: https://solana.com/docs/rpc/http/getleaderschedule
+func (c *Client) GetLeaderSchedule(
+	ctx context.Context, commitment Commitment,
+) (map[string][]int64, error) {
+	config := map[string]any{"commitment": string(commitment)}
+	var resp response[map[string][]int64]
+	if err := c.getResponse(ctx, "getLeaderSchedule", []any{nil, config}, &resp); err != nil {
 		return nil, err
 	}
 	return resp.Result, nil

--- a/pkg/rpc/responses.go
+++ b/pkg/rpc/responses.go
@@ -72,6 +72,23 @@ type (
 		Epoch         int64 `json:"epoch"`
 		PostBalance   int64 `json:"postBalance"`
 	}
+
+	Block struct {
+		BlockHeight       int64         `json:"blockHeight"`
+		BlockTime         int64         `json:"blockTime,omitempty"`
+		Blockhash         string        `json:"blockhash"`
+		ParentSlot        int64         `json:"parentSlot"`
+		PreviousBlockhash string        `json:"previousBlockhash"`
+		Rewards           []BlockReward `json:"rewards"`
+	}
+
+	BlockReward struct {
+		Pubkey      string `json:"pubkey"`
+		Lamports    int64  `json:"lamports"`
+		PostBalance int64  `json:"postBalance"`
+		RewardType  string `json:"rewardType"`
+		Commission  uint8  `json:"commission"`
+	}
 )
 
 func (hp *HostProduction) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
The main thing done here is adding fee reward tracking. This is done by calling `getBlock` for the slots which we produced and getting the fee reward.

Additionally, I also added explicit use of commitment levels for `rpc.Client` methods.

The error handling in this is suboptimal, but improved in an upcoming PR (#40).