### PR TITLE
Remove link to deprecated docker hub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ solana_exporter exports basic monitoring data from a Solana node.
 
 <img src="https://i.imgur.com/2pIXLyU.png" width="550px" alt="" />
 
-Docker images are available on [Docker Hub](https://hub.docker.com/r/certusone/solana_exporter).
-
 ## Metrics
 
 Metrics tracked with confirmation level `recent`:
@@ -13,7 +11,7 @@ Metrics tracked with confirmation level `recent`:
 - **solana_validator_root_slot** - Latest root seen by each validator.
 - **solana_validator_last_vote** - Latest vote by each validator (not necessarily on the majority fork!)
 - **solana_validator_delinquent** - Whether node considers each validator to be delinquent.
-- **solana_validator_activated_stake**  - Active stake for each validator. 
+- **solana_validator_activated_stake**  - Active stake for each validator.
 - **solana_active_validators** - Total number of active/delinquent validators.
 
 Metrics tracked with confirmation level `max`:
@@ -34,7 +32,7 @@ Metrics with no confirmation level:
 You typically only need to set the RPC URL, pointing to one of your own nodes:
 
     ./solana_exporter -rpcURI=http://yournode:8899
-    
+
 If you want verbose logs, specify `-v=<num>`. Higher verbosity means more debug output. For most users, the default
 verbosity level is fine. If you want detailed log output for missed blocks, run with `-v=1`.
 


### PR DESCRIPTION
This is not currently used, though we might update to a new one in the future.

Fixes: #39