### PR TITLE
Refactored config

### DIFF
--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -30,12 +30,25 @@ const (
 )
 
 var (
-	httpTimeout     = 60 * time.Second
-	rpcUrl          = flag.String("rpc-url", "", "Solana RPC URI (including protocol and path)")
-	listenAddress   = flag.String("listen-address", ":8080", "Listen address")
-	httpTimeoutSecs = flag.Int("http-timeout", 60, "HTTP timeout to use, in seconds.")
-
-	// addresses:
+	httpTimeout = 60 * time.Second
+	// general config:
+	rpcUrl = flag.String(
+		"rpc-url",
+		"http://localhost:8899",
+		"Solana RPC URL (including protocol and path), "+
+			"e.g., 'http://localhost:8899' or 'https://api.mainnet-beta.solana.com'",
+	)
+	listenAddress = flag.String(
+		"listen-address",
+		":8080",
+		"Listen address",
+	)
+	httpTimeoutSecs = flag.Int(
+		"http-timeout",
+		60,
+		"HTTP timeout to use, in seconds.",
+	)
+	// parameters to specify what we're tracking:
 	nodekeys = flag.String(
 		"nodekeys",
 		"",
@@ -228,10 +241,6 @@ func (c *SolanaCollector) Collect(ch chan<- prometheus.Metric) {
 func main() {
 	ctx := context.Background()
 	flag.Parse()
-
-	if *rpcUrl == "" {
-		klog.Fatal("Please specify -rpcURI")
-	}
 
 	if *comprehensiveSlotTracking {
 		klog.Warning(

--- a/cmd/solana_exporter/slots_test.go
+++ b/cmd/solana_exporter/slots_test.go
@@ -92,10 +92,9 @@ func TestSolanaCollector_WatchSlots_Static(t *testing.T) {
 	leaderSlotsTotal.Reset()
 	leaderSlotsByEpoch.Reset()
 
-	collector := createSolanaCollector(
-		&staticRPCClient{}, 100*time.Millisecond, identities, []string{}, votekeys, identities,
-	)
-	watcher := NewCollectorSlotWatcher(collector)
+	client := staticRPCClient{}
+	collector := NewSolanaCollector(&client, 100*time.Millisecond, nil, identities, votekeys)
+	watcher := NewSlotWatcher(&client, identities, votekeys, false)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -163,8 +162,8 @@ func TestSolanaCollector_WatchSlots_Dynamic(t *testing.T) {
 
 	// create clients:
 	client := newDynamicRPCClient()
-	collector := createSolanaCollector(client, 300*time.Millisecond, identities, []string{}, votekeys, identities)
-	watcher := NewCollectorSlotWatcher(collector)
+	collector := NewSolanaCollector(client, 300*time.Millisecond, nil, identities, votekeys)
+	watcher := NewSlotWatcher(client, identities, votekeys, false)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 
 	// start client/collector and wait a bit:

--- a/cmd/solana_exporter/utils_test.go
+++ b/cmd/solana_exporter/utils_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"github.com/asymmetric-research/solana_exporter/pkg/rpc"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -44,4 +45,14 @@ func TestFetchBalances(t *testing.T) {
 	fetchedBalances, err := FetchBalances(ctx, &client, CombineUnique(identities, votekeys))
 	assert.NoError(t, err)
 	assert.Equal(t, balances, fetchedBalances)
+}
+
+func TestGetAssociatedVoteAccounts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := staticRPCClient{}
+	voteAccounts, err := GetAssociatedVoteAccounts(ctx, &client, rpc.CommitmentFinalized, identities)
+	assert.NoError(t, err)
+	assert.Equal(t, votekeys, voteAccounts)
 }

--- a/cmd/solana_exporter/utils_test.go
+++ b/cmd/solana_exporter/utils_test.go
@@ -22,3 +22,26 @@ func TestGetTrimmedLeaderSchedule(t *testing.T) {
 
 	assert.Equal(t, map[string][]int64{"aaa": {10, 13, 16, 19, 22}, "bbb": {11, 14, 17, 20, 23}}, schedule)
 }
+
+func TestCombineUnique(t *testing.T) {
+	var (
+		v1 = []string{"1", "2", "3"}
+		v2 = []string{"2", "3", "4"}
+		v3 = []string{"3", "4", "5"}
+	)
+
+	assert.Equal(t, []string{"1", "2", "3", "4", "5"}, CombineUnique(v1, v2, v3))
+	assert.Equal(t, []string{"2", "3", "4", "5"}, CombineUnique(nil, v2, v3))
+	assert.Equal(t, []string{"1", "2", "3", "4", "5"}, CombineUnique(v1, nil, v3))
+
+}
+
+func TestFetchBalances(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := staticRPCClient{}
+	fetchedBalances, err := FetchBalances(ctx, &client, CombineUnique(identities, votekeys))
+	assert.NoError(t, err)
+	assert.Equal(t, balances, fetchedBalances)
+}


### PR DESCRIPTION
## Config Simplification

 * Instead of separately configuring `inflation-reward-addresses`, `fee-reward-addresses`, `balance-addresses`, and `leader-slot-addresses`, you now configure `balance-addresses`, `nodekeys` and `comprehensive-slot-tracking`.
 * Vote accounts are inferred from the `nodekeys` using the [getVoteAccounts](https://solana.com/docs/rpc/http/getvoteaccounts) RPC, and then we have:
   * `inflation-reward-addresses -> votekeys`
   * `fee-reward-addresses -> nodekeys`
   * `balance-addresses -> votekeys + nodekeys + balance-addresses` (i.e., `balance-addresses` is now used to configure extra accounts you want to track balances for, in addition to the configured validator accounts)
 * Removed the `votePubkey` config option.

## Label Standardisation

Previously, vote accounts were referred to under the rather generically named `pubkey` label, which has now been replaced with `votekey`. Additionally, the labels are all explicitly written as constants.

**NOTE**: If we move forward with this one, it will be a breaking change that will affect the way metrics are stored in Prometheus.

## Other changes

* changed `http_timeout` flag to `http-timeout`
* Added default value for `rpc-url` (also changed `rpcURI` to `rpc-url`