### PR TITLE
Added rpc error data

### DIFF
--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -131,7 +131,7 @@ func getResponse[T any](
 		return fmt.Errorf("failed to decode %s response body: %w", method, err)
 	}
 
-	// last error check:
+	// check for an actual rpc error
 	if rpcResponse.Error.Code != 0 {
 		return &rpcResponse.Error
 	}

--- a/pkg/rpc/responses.go
+++ b/pkg/rpc/responses.go
@@ -7,8 +7,9 @@ import (
 
 type (
 	RPCError struct {
-		Message string `json:"message"`
-		Code    int64  `json:"code"`
+		Message string         `json:"message"`
+		Code    int64          `json:"code"`
+		Data    map[string]any `json:"data"`
 	}
 
 	response[T any] struct {
@@ -97,7 +98,7 @@ type (
 )
 
 func (e *RPCError) Error() string {
-	return fmt.Sprintf("RPC Error (%d): %s", e.Code, e.Message)
+	return fmt.Sprintf("rpc error (code: %d): %s (data: %v)", e.Code, e.Message, e.Data)
 }
 
 func (hp *HostProduction) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
This can probably be refined in the future, but for now this should allow us to extract `getHealth` error data, see https://solana.com/docs/rpc/http/gethealth