### PR TITLE
More config updates

### DIFF
--- a/cmd/solana_exporter/config.go
+++ b/cmd/solana_exporter/config.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+)
+
+type (
+	arrayFlags []string
+
+	ExporterConfig struct {
+		HttpTimeout               time.Duration
+		RpcUrl                    string
+		ListenAddress             string
+		NodeKeys                  []string
+		BalanceAddresses          []string
+		ComprehensiveSlotTracking bool
+	}
+)
+
+func (i *arrayFlags) String() string {
+	return fmt.Sprint(*i)
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+func NewExporterConfig(
+	httpTimeout int,
+	rpcUrl string,
+	listenAddress string,
+	nodeKeys []string,
+	balanceAddresses []string,
+	comprehensiveSlotTracking bool,
+) *ExporterConfig {
+	return &ExporterConfig{
+		HttpTimeout:               time.Duration(httpTimeout) * time.Second,
+		RpcUrl:                    rpcUrl,
+		ListenAddress:             listenAddress,
+		NodeKeys:                  nodeKeys,
+		BalanceAddresses:          balanceAddresses,
+		ComprehensiveSlotTracking: comprehensiveSlotTracking,
+	}
+}
+
+func NewExporterConfigFromCLI() *ExporterConfig {
+	var (
+		httpTimeout               int
+		rpcUrl                    string
+		listenAddress             string
+		nodekeys                  arrayFlags
+		balanceAddresses          arrayFlags
+		comprehensiveSlotTracking bool
+	)
+	flag.IntVar(
+		&httpTimeout,
+		"http-timeout",
+		60,
+		"HTTP timeout to use, in seconds.",
+	)
+	flag.StringVar(
+		&rpcUrl,
+		"rpc-url",
+		"http://localhost:8899",
+		"Solana RPC URL (including protocol and path), "+
+			"e.g., 'http://localhost:8899' or 'https://api.mainnet-beta.solana.com'",
+	)
+	flag.StringVar(
+		&listenAddress,
+		"listen-address",
+		":8080",
+		"Listen address",
+	)
+	flag.Var(
+		&nodekeys,
+		"nodekey",
+		"Solana nodekey (identity account) representing validator to monitor - can set multiple times.",
+	)
+	flag.Var(
+		&balanceAddresses,
+		"balance-address",
+		"Address to monitor SOL balances for, in addition to the identity and vote accounts of the "+
+			"provided nodekeys - can be set multiple times.",
+	)
+	flag.BoolVar(
+		&comprehensiveSlotTracking,
+		"comprehensive-slot-tracking",
+		false,
+		"Set this flag to track solana_leader_slots_by_epoch for ALL validators. "+
+			"Warning: this will lead to potentially thousands of new Prometheus metrics being created every epoch.",
+	)
+	flag.Parse()
+
+	return NewExporterConfig(httpTimeout, rpcUrl, listenAddress, nodekeys, balanceAddresses, comprehensiveSlotTracking)
+}

--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -209,15 +209,15 @@ func main() {
 	}
 
 	client := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout)
-	ctx_, cancel := context.WithTimeout(ctx, config.HttpTimeout)
-	defer cancel()
-	votekeys, err := GetAssociatedVoteAccounts(ctx_, client, rpc.CommitmentFinalized, config.NodeKeys)
+	votekeys, err := GetAssociatedVoteAccounts(ctx, client, rpc.CommitmentFinalized, config.NodeKeys)
 	if err != nil {
 		klog.Fatalf("Failed to get associated vote accounts for %v: %v", config.NodeKeys, err)
 	}
 
 	collector := NewSolanaCollector(client, slotPacerSchedule, config.BalanceAddresses, config.NodeKeys, votekeys)
 	slotWatcher := NewSlotWatcher(client, config.NodeKeys, votekeys, config.ComprehensiveSlotTracking)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go slotWatcher.WatchSlots(ctx, collector.slotPace)
 
 	prometheus.MustRegister(collector)

--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"context"
-	"flag"
 	"github.com/asymmetric-research/solana_exporter/pkg/rpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
-	"strings"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -27,45 +25,6 @@ const (
 
 	StateCurrent    = "current"
 	StateDelinquent = "delinquent"
-)
-
-var (
-	httpTimeout = 60 * time.Second
-	// general config:
-	rpcUrl = flag.String(
-		"rpc-url",
-		"http://localhost:8899",
-		"Solana RPC URL (including protocol and path), "+
-			"e.g., 'http://localhost:8899' or 'https://api.mainnet-beta.solana.com'",
-	)
-	listenAddress = flag.String(
-		"listen-address",
-		":8080",
-		"Listen address",
-	)
-	httpTimeoutSecs = flag.Int(
-		"http-timeout",
-		60,
-		"HTTP timeout to use, in seconds.",
-	)
-	// parameters to specify what we're tracking:
-	nodekeys = flag.String(
-		"nodekeys",
-		"",
-		"Comma-separated list of nodekeys (identity accounts) representing validators to monitor.",
-	)
-	comprehensiveSlotTracking = flag.Bool(
-		"comprehensive-slot-tracking",
-		false,
-		"Set this flag to track solana_leader_slots_by_epoch for ALL validators. "+
-			"Warning: this will lead to potentially thousands of new Prometheus metrics being created every epoch.",
-	)
-	balanceAddresses = flag.String(
-		"balance-addresses",
-		"",
-		"Comma-separated list of addresses to monitor SOL balances for, "+
-			"in addition to the identity and vote accounts of the provided nodekeys.",
-	)
 )
 
 func init() {
@@ -230,7 +189,7 @@ func (c *SolanaCollector) collectBalances(ctx context.Context, ch chan<- prometh
 }
 
 func (c *SolanaCollector) Collect(ch chan<- prometheus.Metric) {
-	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	c.collectVoteAccounts(ctx, ch)
@@ -240,43 +199,30 @@ func (c *SolanaCollector) Collect(ch chan<- prometheus.Metric) {
 
 func main() {
 	ctx := context.Background()
-	flag.Parse()
 
-	if *comprehensiveSlotTracking {
+	config := NewExporterConfigFromCLI()
+	if config.ComprehensiveSlotTracking {
 		klog.Warning(
 			"Comprehensive slot tracking will lead to potentially thousands of new " +
 				"Prometheus metrics being created every epoch.",
 		)
 	}
 
-	httpTimeout = time.Duration(*httpTimeoutSecs) * time.Second
-
-	var (
-		balAddresses      []string
-		validatorNodekeys []string
-	)
-	if *balanceAddresses != "" {
-		balAddresses = strings.Split(*balanceAddresses, ",")
-	}
-	if *nodekeys != "" {
-		validatorNodekeys = strings.Split(*nodekeys, ",")
-		klog.Infof("Monitoring the following validators: %v", validatorNodekeys)
-	}
-
-	client := rpc.NewRPCClient(*rpcUrl)
-	ctx_, cancel := context.WithTimeout(ctx, httpTimeout)
+	client := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout)
+	ctx_, cancel := context.WithTimeout(ctx, config.HttpTimeout)
 	defer cancel()
-	votekeys, err := GetAssociatedVoteAccounts(ctx_, client, rpc.CommitmentFinalized, validatorNodekeys)
+	votekeys, err := GetAssociatedVoteAccounts(ctx_, client, rpc.CommitmentFinalized, config.NodeKeys)
 	if err != nil {
-		klog.Fatalf("Failed to get associated vote accounts for %v: %v", nodekeys, err)
+		klog.Fatalf("Failed to get associated vote accounts for %v: %v", config.NodeKeys, err)
 	}
-	collector := NewSolanaCollector(client, slotPacerSchedule, balAddresses, validatorNodekeys, votekeys)
-	slotWatcher := NewSlotWatcher(client, validatorNodekeys, votekeys, *comprehensiveSlotTracking)
+
+	collector := NewSolanaCollector(client, slotPacerSchedule, config.BalanceAddresses, config.NodeKeys, votekeys)
+	slotWatcher := NewSlotWatcher(client, config.NodeKeys, votekeys, config.ComprehensiveSlotTracking)
 	go slotWatcher.WatchSlots(ctx, collector.slotPace)
 
 	prometheus.MustRegister(collector)
 	http.Handle("/metrics", promhttp.Handler())
 
-	klog.Infof("listening on %s", *listenAddress)
-	klog.Fatal(http.ListenAndServe(*listenAddress, nil))
+	klog.Infof("listening on %s", config.ListenAddress)
+	klog.Fatal(http.ListenAndServe(config.ListenAddress, nil))
 }

--- a/cmd/solana_exporter/slots.go
+++ b/cmd/solana_exporter/slots.go
@@ -35,88 +35,88 @@ type SlotWatcher struct {
 	slotWatermark int64
 
 	leaderSchedule map[string][]int64
+
+	// prometheus:
+	TotalTransactionsMetric  prometheus.Gauge
+	SlotHeightMetric         prometheus.Gauge
+	EpochNumberMetric        prometheus.Gauge
+	EpochFirstSlotMetric     prometheus.Gauge
+	EpochLastSlotMetric      prometheus.Gauge
+	LeaderSlotsTotalMetric   *prometheus.CounterVec
+	LeaderSlotsByEpochMetric *prometheus.CounterVec
+	InflationRewardsMetric   *prometheus.GaugeVec
+	FeeRewardsMetric         *prometheus.CounterVec
 }
-
-var (
-	totalTransactionsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "solana_confirmed_transactions_total",
-		Help: "Total number of transactions processed since genesis (max confirmation)",
-	})
-
-	confirmedSlotHeight = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "solana_confirmed_slot_height",
-		Help: "Last confirmed slot height processed by watcher routine (max confirmation)",
-	})
-
-	currentEpochNumber = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "solana_confirmed_epoch_number",
-		Help: "Current epoch (max confirmation)",
-	})
-
-	epochFirstSlot = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "solana_confirmed_epoch_first_slot",
-		Help: "Current epoch's first slot (max confirmation)",
-	})
-
-	epochLastSlot = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "solana_confirmed_epoch_last_slot",
-		Help: "Current epoch's last slot (max confirmation)",
-	})
-
-	leaderSlotsTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "solana_leader_slots_total",
-			Help: "(DEPRECATED) Number of leader slots per leader, grouped by skip status",
-		},
-		[]string{SkipStatusLabel, NodekeyLabel},
-	)
-
-	leaderSlotsByEpoch = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "solana_leader_slots_by_epoch",
-			Help: "Number of leader slots per leader, grouped by skip status and epoch",
-		},
-		[]string{SkipStatusLabel, NodekeyLabel, EpochLabel},
-	)
-
-	inflationRewards = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "solana_inflation_rewards",
-			Help: "Inflation reward earned per validator vote account, per epoch",
-		},
-		[]string{VotekeyLabel, EpochLabel},
-	)
-
-	feeRewards = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "solana_fee_rewards",
-			Help: "Transaction fee rewards earned per validator identity account, per epoch",
-		},
-		[]string{NodekeyLabel, EpochLabel},
-	)
-)
 
 func NewSlotWatcher(
 	client rpc.Provider, nodekeys []string, votekeys []string, comprehensiveSlotTracking bool,
 ) *SlotWatcher {
-	return &SlotWatcher{
+	watcher := SlotWatcher{
 		client:                    client,
 		nodekeys:                  nodekeys,
 		votekeys:                  votekeys,
 		comprehensiveSlotTracking: comprehensiveSlotTracking,
+		// metrics:
+		TotalTransactionsMetric: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "solana_confirmed_transactions_total",
+			Help: "Total number of transactions processed since genesis (max confirmation)",
+		}),
+		SlotHeightMetric: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "solana_confirmed_slot_height",
+			Help: "Last confirmed slot height processed by watcher routine (max confirmation)",
+		}),
+		EpochNumberMetric: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "solana_confirmed_epoch_number",
+			Help: "Current epoch (max confirmation)",
+		}),
+		EpochFirstSlotMetric: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "solana_confirmed_epoch_first_slot",
+			Help: "Current epoch's first slot (max confirmation)",
+		}),
+		EpochLastSlotMetric: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "solana_confirmed_epoch_last_slot",
+			Help: "Current epoch's last slot (max confirmation)",
+		}),
+		LeaderSlotsTotalMetric: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "solana_leader_slots_total",
+				Help: "(DEPRECATED) Number of leader slots per leader, grouped by skip status",
+			},
+			[]string{SkipStatusLabel, NodekeyLabel},
+		),
+		LeaderSlotsByEpochMetric: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "solana_leader_slots_by_epoch",
+				Help: "Number of leader slots per leader, grouped by skip status and epoch",
+			},
+			[]string{SkipStatusLabel, NodekeyLabel, EpochLabel},
+		),
+		InflationRewardsMetric: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "solana_inflation_rewards",
+				Help: "Inflation reward earned per validator vote account, per epoch",
+			},
+			[]string{VotekeyLabel, EpochLabel},
+		),
+		FeeRewardsMetric: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "solana_fee_rewards",
+				Help: "Transaction fee rewards earned per validator identity account, per epoch",
+			},
+			[]string{NodekeyLabel, EpochLabel},
+		),
 	}
-}
-
-func init() {
-	prometheus.MustRegister(totalTransactionsTotal)
-	prometheus.MustRegister(confirmedSlotHeight)
-	prometheus.MustRegister(currentEpochNumber)
-	prometheus.MustRegister(epochFirstSlot)
-	prometheus.MustRegister(epochLastSlot)
-	prometheus.MustRegister(leaderSlotsTotal)
-	prometheus.MustRegister(leaderSlotsByEpoch)
-	prometheus.MustRegister(inflationRewards)
-	prometheus.MustRegister(feeRewards)
+	// register:
+	prometheus.MustRegister(watcher.TotalTransactionsMetric)
+	prometheus.MustRegister(watcher.SlotHeightMetric)
+	prometheus.MustRegister(watcher.EpochNumberMetric)
+	prometheus.MustRegister(watcher.EpochFirstSlotMetric)
+	prometheus.MustRegister(watcher.EpochLastSlotMetric)
+	prometheus.MustRegister(watcher.LeaderSlotsTotalMetric)
+	prometheus.MustRegister(watcher.LeaderSlotsByEpochMetric)
+	prometheus.MustRegister(watcher.InflationRewardsMetric)
+	prometheus.MustRegister(watcher.FeeRewardsMetric)
+	return &watcher
 }
 
 func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
@@ -132,12 +132,9 @@ func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
 			return
 		default:
 			<-ticker.C
-
-			ctx_, cancel := context.WithTimeout(ctx, httpTimeout)
 			// TODO: separate fee-rewards watching from general slot watching, such that general slot watching commitment level can be dropped to confirmed
 			commitment := rpc.CommitmentFinalized
-			epochInfo, err := c.client.GetEpochInfo(ctx_, commitment)
-			cancel()
+			epochInfo, err := c.client.GetEpochInfo(ctx, commitment)
 			if err != nil {
 				klog.Errorf("Failed to get epoch info, bailing out: %v", err)
 				continue
@@ -148,8 +145,8 @@ func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
 				c.trackEpoch(ctx, epochInfo)
 			}
 
-			totalTransactionsTotal.Set(float64(epochInfo.TransactionCount))
-			confirmedSlotHeight.Set(float64(epochInfo.AbsoluteSlot))
+			c.TotalTransactionsMetric.Set(float64(epochInfo.TransactionCount))
+			c.SlotHeightMetric.Set(float64(epochInfo.AbsoluteSlot))
 
 			// if we get here, then the tracking numbers are set, so this is a "normal" run.
 			// start by checking if we have progressed since last run:
@@ -216,13 +213,11 @@ func (c *SlotWatcher) trackEpoch(ctx context.Context, epoch *rpc.EpochInfo) {
 
 	// emit epoch bounds:
 	klog.Infof("Emitting epoch bounds: %v (slots %v -> %v)", c.currentEpoch, c.firstSlot, c.lastSlot)
-	currentEpochNumber.Set(float64(c.currentEpoch))
-	epochFirstSlot.Set(float64(c.firstSlot))
-	epochLastSlot.Set(float64(c.lastSlot))
+	c.EpochNumberMetric.Set(float64(c.currentEpoch))
+	c.EpochFirstSlotMetric.Set(float64(c.firstSlot))
+	c.EpochLastSlotMetric.Set(float64(c.lastSlot))
 
 	// update leader schedule:
-	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
-	defer cancel()
 	klog.Infof("Updating leader schedule for epoch %v ...", c.currentEpoch)
 	leaderSchedule, err := GetTrimmedLeaderSchedule(ctx, c.client, c.nodekeys, epoch.AbsoluteSlot, c.firstSlot)
 	if err != nil {
@@ -273,8 +268,6 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 	}
 
 	// fetch block production:
-	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
-	defer cancel()
 	blockProduction, err := c.client.GetBlockProduction(ctx, rpc.CommitmentFinalized, nil, &startSlot, &endSlot)
 	if err != nil {
 		klog.Errorf("Failed to get block production, bailing out: %v", err)
@@ -286,13 +279,13 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 		valid := float64(production.BlocksProduced)
 		skipped := float64(production.LeaderSlots - production.BlocksProduced)
 
-		leaderSlotsTotal.WithLabelValues(StatusValid, address).Add(valid)
-		leaderSlotsTotal.WithLabelValues(StatusSkipped, address).Add(skipped)
+		c.LeaderSlotsTotalMetric.WithLabelValues(StatusValid, address).Add(valid)
+		c.LeaderSlotsTotalMetric.WithLabelValues(StatusSkipped, address).Add(skipped)
 
 		if slices.Contains(c.nodekeys, address) || c.comprehensiveSlotTracking {
 			epochStr := toString(c.currentEpoch)
-			leaderSlotsByEpoch.WithLabelValues(StatusValid, address, epochStr).Add(valid)
-			leaderSlotsByEpoch.WithLabelValues(StatusSkipped, address, epochStr).Add(skipped)
+			c.LeaderSlotsByEpochMetric.WithLabelValues(StatusValid, address, epochStr).Add(valid)
+			c.LeaderSlotsByEpochMetric.WithLabelValues(StatusSkipped, address, epochStr).Add(skipped)
 		}
 	}
 
@@ -316,9 +309,7 @@ func (c *SlotWatcher) fetchAndEmitFeeRewards(ctx context.Context, endSlot int64)
 
 		klog.Infof("Fetching fee rewards for %v in [%v -> %v]: %v ...", identity, startSlot, endSlot, leaderSlots)
 		for _, slot := range leaderSlots {
-			ctx, cancel := context.WithTimeout(ctx, httpTimeout)
 			err := c.fetchAndEmitSingleFeeReward(ctx, identity, c.currentEpoch, slot)
-			cancel()
 			if err != nil {
 				klog.Errorf("Failed to fetch fee rewards for %v at %v: %v", identity, slot, err)
 			}
@@ -355,7 +346,7 @@ func (c *SlotWatcher) fetchAndEmitSingleFeeReward(
 				reward.Pubkey,
 			)
 			amount := float64(reward.Lamports) / float64(rpc.LamportsInSol)
-			feeRewards.WithLabelValues(identity, toString(epoch)).Add(amount)
+			c.FeeRewardsMetric.WithLabelValues(identity, toString(epoch)).Add(amount)
 		}
 	}
 
@@ -372,10 +363,6 @@ func getEpochBounds(info *rpc.EpochInfo) (int64, int64) {
 // at the provided epoch
 func (c *SlotWatcher) fetchAndEmitInflationRewards(ctx context.Context, epoch int64) error {
 	klog.Infof("Fetching inflation reward for epoch %v ...", toString(epoch))
-
-	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
-	defer cancel()
-
 	rewardInfos, err := c.client.GetInflationReward(ctx, rpc.CommitmentConfirmed, c.votekeys, &epoch, nil)
 	if err != nil {
 		return fmt.Errorf("error fetching inflation rewards: %w", err)
@@ -384,7 +371,7 @@ func (c *SlotWatcher) fetchAndEmitInflationRewards(ctx context.Context, epoch in
 	for i, rewardInfo := range rewardInfos {
 		address := c.votekeys[i]
 		reward := float64(rewardInfo.Amount) / float64(rpc.LamportsInSol)
-		inflationRewards.WithLabelValues(address, toString(epoch)).Set(reward)
+		c.InflationRewardsMetric.WithLabelValues(address, toString(epoch)).Set(reward)
 	}
 	klog.Infof("Fetched inflation reward for epoch %v.", epoch)
 	return nil


### PR DESCRIPTION
## Removing global variables

Personally I was getting quite confused tracking all the global variables. This PR aims to get rid of those in the following ways:
 * Attaching the metrics associated with the `SlotWatcher` to the slot-watcher object.
 * Creating a `ExporterConfig` object which is created on start-up (this also facilitates config testing).
   * In the process here, i also figured I would change the `nodekeys` and `balanceAddresses` config flags to variables which can be set multiple times (`-nodekey $val1 -nodekey $val2`) instead of comma-separated lists (`-nodekeys $val1,$val2`)
 * Attaching the `httpTimeout` to the `rpc.Client`