### PR TITLE
Block sizes!

### DIFF
--- a/cmd/solana_exporter/config.go
+++ b/cmd/solana_exporter/config.go
@@ -16,6 +16,7 @@ type (
 		NodeKeys                  []string
 		BalanceAddresses          []string
 		ComprehensiveSlotTracking bool
+		MonitorBlockSizes         bool
 	}
 )
 
@@ -35,6 +36,7 @@ func NewExporterConfig(
 	nodeKeys []string,
 	balanceAddresses []string,
 	comprehensiveSlotTracking bool,
+	monitorBlockSizes bool,
 ) *ExporterConfig {
 	return &ExporterConfig{
 		HttpTimeout:               time.Duration(httpTimeout) * time.Second,
@@ -43,6 +45,7 @@ func NewExporterConfig(
 		NodeKeys:                  nodeKeys,
 		BalanceAddresses:          balanceAddresses,
 		ComprehensiveSlotTracking: comprehensiveSlotTracking,
+		MonitorBlockSizes:         monitorBlockSizes,
 	}
 }
 
@@ -54,6 +57,7 @@ func NewExporterConfigFromCLI() *ExporterConfig {
 		nodekeys                  arrayFlags
 		balanceAddresses          arrayFlags
 		comprehensiveSlotTracking bool
+		monitorBlockSizes         bool
 	)
 	flag.IntVar(
 		&httpTimeout,
@@ -92,7 +96,16 @@ func NewExporterConfigFromCLI() *ExporterConfig {
 		"Set this flag to track solana_leader_slots_by_epoch for ALL validators. "+
 			"Warning: this will lead to potentially thousands of new Prometheus metrics being created every epoch.",
 	)
+	flag.BoolVar(
+		&monitorBlockSizes,
+		"monitor-block-sizes",
+		false,
+		"Set this flag to track block sizes (number of transactions) for the configured validators. "+
+			"Warning: this might grind the RPC node.",
+	)
 	flag.Parse()
 
-	return NewExporterConfig(httpTimeout, rpcUrl, listenAddress, nodekeys, balanceAddresses, comprehensiveSlotTracking)
+	return NewExporterConfig(
+		httpTimeout, rpcUrl, listenAddress, nodekeys, balanceAddresses, comprehensiveSlotTracking, monitorBlockSizes,
+	)
 }

--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -57,13 +57,13 @@ func NewSolanaCollector(
 		balanceAddresses: CombineUnique(balanceAddresses, nodekeys, votekeys),
 		totalValidatorsDesc: prometheus.NewDesc(
 			"solana_active_validators",
-			"Total number of active validators grouped by state (i.e., 'current' vs 'delinquent')",
+			"Total number of active validators by state",
 			[]string{StateLabel},
 			nil,
 		),
 		validatorActivatedStake: prometheus.NewDesc(
 			"solana_validator_activated_stake",
-			"Activated stake per validator, in SOL.",
+			"Activated stake per validator",
 			[]string{VotekeyLabel, NodekeyLabel},
 			nil,
 		),

--- a/cmd/solana_exporter/exporter.go
+++ b/cmd/solana_exporter/exporter.go
@@ -57,13 +57,13 @@ func NewSolanaCollector(
 		balanceAddresses: CombineUnique(balanceAddresses, nodekeys, votekeys),
 		totalValidatorsDesc: prometheus.NewDesc(
 			"solana_active_validators",
-			"Total number of active validators by state",
+			"Total number of active validators grouped by state (i.e., 'current' vs 'delinquent')",
 			[]string{StateLabel},
 			nil,
 		),
 		validatorActivatedStake: prometheus.NewDesc(
 			"solana_validator_activated_stake",
-			"Activated stake per validator",
+			"Activated stake per validator, in SOL.",
 			[]string{VotekeyLabel, NodekeyLabel},
 			nil,
 		),
@@ -215,7 +215,9 @@ func main() {
 	}
 
 	collector := NewSolanaCollector(client, slotPacerSchedule, config.BalanceAddresses, config.NodeKeys, votekeys)
-	slotWatcher := NewSlotWatcher(client, config.NodeKeys, votekeys, config.ComprehensiveSlotTracking)
+	slotWatcher := NewSlotWatcher(
+		client, config.NodeKeys, votekeys, config.ComprehensiveSlotTracking, config.MonitorBlockSizes,
+	)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go slotWatcher.WatchSlots(ctx, collector.slotPace)

--- a/cmd/solana_exporter/exporter_test.go
+++ b/cmd/solana_exporter/exporter_test.go
@@ -172,7 +172,9 @@ func (c *staticRPCClient) GetLeaderSchedule(
 }
 
 //goland:noinspection GoUnusedParameter
-func (c *staticRPCClient) GetBlock(ctx context.Context, commitment rpc.Commitment, slot int64) (*rpc.Block, error) {
+func (c *staticRPCClient) GetBlock(
+	ctx context.Context, commitment rpc.Commitment, slot int64, transactionDetails string,
+) (*rpc.Block, error) {
 	return nil, nil
 }
 
@@ -365,7 +367,9 @@ func (c *dynamicRPCClient) GetLeaderSchedule(
 }
 
 //goland:noinspection GoUnusedParameter
-func (c *dynamicRPCClient) GetBlock(ctx context.Context, commitment rpc.Commitment, slot int64) (*rpc.Block, error) {
+func (c *dynamicRPCClient) GetBlock(
+	ctx context.Context, commitment rpc.Commitment, slot int64, transactionDetails string,
+) (*rpc.Block, error) {
 	return nil, nil
 }
 

--- a/cmd/solana_exporter/slots.go
+++ b/cmd/solana_exporter/slots.go
@@ -280,7 +280,7 @@ func (c *SlotWatcher) checkValidSlotRange(from, to int64) error {
 // moveSlotWatermark performs all the slot-watching tasks required to move the slotWatermark to the provided 'to' slot.
 func (c *SlotWatcher) moveSlotWatermark(ctx context.Context, to int64) {
 	c.fetchAndEmitBlockProduction(ctx, to)
-	c.fetchAndEmitFeeRewards(ctx, to)
+	c.fetchAndEmitBlockInfos(ctx, to)
 	c.slotWatermark = to
 }
 
@@ -321,9 +321,9 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 	klog.Infof("Fetched block production in [%v -> %v]", startSlot, endSlot)
 }
 
-// fetchAndEmitFeeRewards fetches and emits all the fee rewards (+ block sizes) for the tracked addresses between the
+// fetchAndEmitBlockInfos fetches and emits all the fee rewards (+ block sizes) for the tracked addresses between the
 // slotWatermark and endSlot
-func (c *SlotWatcher) fetchAndEmitFeeRewards(ctx context.Context, endSlot int64) {
+func (c *SlotWatcher) fetchAndEmitBlockInfos(ctx context.Context, endSlot int64) {
 	startSlot := c.slotWatermark + 1
 	klog.Infof("Fetching fee rewards in [%v -> %v]", startSlot, endSlot)
 
@@ -338,7 +338,7 @@ func (c *SlotWatcher) fetchAndEmitFeeRewards(ctx context.Context, endSlot int64)
 
 		klog.Infof("Fetching fee rewards for %v in [%v -> %v]: %v ...", identity, startSlot, endSlot, leaderSlots)
 		for _, slot := range leaderSlots {
-			err := c.fetchAndEmitSingleFeeReward(ctx, identity, c.currentEpoch, slot)
+			err := c.fetchAndEmitSingleBlockInfo(ctx, identity, c.currentEpoch, slot)
 			if err != nil {
 				klog.Errorf("Failed to fetch fee rewards for %v at %v: %v", identity, slot, err)
 			}
@@ -348,8 +348,8 @@ func (c *SlotWatcher) fetchAndEmitFeeRewards(ctx context.Context, endSlot int64)
 	klog.Infof("Fetched fee rewards in [%v -> %v]", startSlot, endSlot)
 }
 
-// fetchAndEmitSingleFeeReward fetches and emits the fee reward + block size for a single block.
-func (c *SlotWatcher) fetchAndEmitSingleFeeReward(
+// fetchAndEmitSingleBlockInfo fetches and emits the fee reward + block size for a single block.
+func (c *SlotWatcher) fetchAndEmitSingleBlockInfo(
 	ctx context.Context, identity string, epoch int64, slot int64,
 ) error {
 	var transactionDetails string

--- a/cmd/solana_exporter/slots_test.go
+++ b/cmd/solana_exporter/slots_test.go
@@ -91,7 +91,7 @@ func assertSlotMetricsChangeCorrectly(t *testing.T, initial slotMetricValues, fi
 func TestSolanaCollector_WatchSlots_Static(t *testing.T) {
 	client := staticRPCClient{}
 	collector := NewSolanaCollector(&client, 100*time.Millisecond, nil, identities, votekeys)
-	watcher := NewSlotWatcher(&client, identities, votekeys, false)
+	watcher := NewSlotWatcher(&client, identities, votekeys, false, false)
 	// reset metrics before running tests:
 	watcher.LeaderSlotsTotalMetric.Reset()
 	watcher.LeaderSlotsByEpochMetric.Reset()
@@ -160,7 +160,7 @@ func TestSolanaCollector_WatchSlots_Dynamic(t *testing.T) {
 	// create clients:
 	client := newDynamicRPCClient()
 	collector := NewSolanaCollector(client, 300*time.Millisecond, nil, identities, votekeys)
-	watcher := NewSlotWatcher(client, identities, votekeys, false)
+	watcher := NewSlotWatcher(client, identities, votekeys, false, false)
 	// reset metrics before running tests:
 	watcher.LeaderSlotsTotalMetric.Reset()
 	watcher.LeaderSlotsByEpochMetric.Reset()

--- a/pkg/rpc/responses.go
+++ b/pkg/rpc/responses.go
@@ -79,12 +79,13 @@ type (
 	}
 
 	Block struct {
-		BlockHeight       int64         `json:"blockHeight"`
-		BlockTime         int64         `json:"blockTime,omitempty"`
-		Blockhash         string        `json:"blockhash"`
-		ParentSlot        int64         `json:"parentSlot"`
-		PreviousBlockhash string        `json:"previousBlockhash"`
-		Rewards           []BlockReward `json:"rewards"`
+		BlockHeight       int64            `json:"blockHeight"`
+		BlockTime         int64            `json:"blockTime,omitempty"`
+		Blockhash         string           `json:"blockhash"`
+		ParentSlot        int64            `json:"parentSlot"`
+		PreviousBlockhash string           `json:"previousBlockhash"`
+		Rewards           []BlockReward    `json:"rewards"`
+		Transactions      []map[string]any `json:"transactions"`
 	}
 
 	BlockReward struct {


### PR DESCRIPTION
Because the `"signatures"` `transactionDetails` option doesn't seem to work, the only options are `accounts` and `full`, which are both very verbose, and turn the `getBlock` query into a sizeable one. Thus, running it on many blocks can potentially be tiresome for an RPC node, hence this metric is optional.