### PR TITLE
Light mode!

### DIFF
--- a/cmd/solana_exporter/exporter_test.go
+++ b/cmd/solana_exporter/exporter_test.go
@@ -454,8 +454,29 @@ func runCollectionTests(t *testing.T, collector prometheus.Collector, testCases 
 	}
 }
 
+func newTestConfig(fast bool) *ExporterConfig {
+	pace := time.Duration(100) * time.Second
+	if fast {
+		pace = time.Duration(500) * time.Millisecond
+	}
+	config := ExporterConfig{
+		time.Second * time.Duration(1),
+		"http://localhost:8899",
+		":8080",
+		identities,
+		votekeys,
+		nil,
+		identity,
+		true,
+		true,
+		false,
+		pace,
+	}
+	return &config
+}
+
 func TestSolanaCollector_Collect_Static(t *testing.T) {
-	collector := NewSolanaCollector(&staticRPCClient{}, slotPacerSchedule, nil, identities, votekeys, identity, false)
+	collector := NewSolanaCollector(&staticRPCClient{}, newTestConfig(false))
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 
 	testCases := []collectionTest{
@@ -475,7 +496,7 @@ func TestSolanaCollector_Collect_Static(t *testing.T) {
 
 func TestSolanaCollector_Collect_Dynamic(t *testing.T) {
 	client := newDynamicRPCClient()
-	collector := NewSolanaCollector(client, slotPacerSchedule, nil, identities, votekeys, identity, false)
+	collector := NewSolanaCollector(client, newTestConfig(false))
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 
 	// start off by testing initial state:

--- a/cmd/solana_exporter/exporter_test.go
+++ b/cmd/solana_exporter/exporter_test.go
@@ -455,7 +455,7 @@ func runCollectionTests(t *testing.T, collector prometheus.Collector, testCases 
 }
 
 func TestSolanaCollector_Collect_Static(t *testing.T) {
-	collector := NewSolanaCollector(&staticRPCClient{}, slotPacerSchedule, nil, identities, votekeys, identity)
+	collector := NewSolanaCollector(&staticRPCClient{}, slotPacerSchedule, nil, identities, votekeys, identity, false)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 
 	testCases := []collectionTest{
@@ -475,7 +475,7 @@ func TestSolanaCollector_Collect_Static(t *testing.T) {
 
 func TestSolanaCollector_Collect_Dynamic(t *testing.T) {
 	client := newDynamicRPCClient()
-	collector := NewSolanaCollector(client, slotPacerSchedule, nil, identities, votekeys, identity)
+	collector := NewSolanaCollector(client, slotPacerSchedule, nil, identities, votekeys, identity, false)
 	prometheus.NewPedanticRegistry().MustRegister(collector)
 
 	// start off by testing initial state:

--- a/cmd/solana_exporter/slots.go
+++ b/cmd/solana_exporter/slots.go
@@ -14,21 +14,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	slotPacerSchedule = 1 * time.Second
-)
-
 type SlotWatcher struct {
 	client rpc.Provider
 	logger *zap.SugaredLogger
 
-	// config:
-	nodekeys                  []string
-	votekeys                  []string
-	identity                  string
-	comprehensiveSlotTracking bool
-	monitorBlockSizes         bool
-	lightMode                 bool
+	config *ExporterConfig
 
 	// currentEpoch is the current epoch we are watching
 	currentEpoch int64
@@ -55,33 +45,12 @@ type SlotWatcher struct {
 	BlockHeight              *prometheus.GaugeVec
 }
 
-func NewSlotWatcher(
-	client rpc.Provider,
-	nodekeys []string,
-	votekeys []string,
-	identity string,
-	comprehensiveSlotTracking bool,
-	monitorBlockSizes bool,
-	lightMode bool,
-) *SlotWatcher {
+func NewSlotWatcher(client rpc.Provider, config *ExporterConfig) *SlotWatcher {
 	logger := slog.Get()
-	logger.Infow(
-		"Creating slot watcher with ",
-		"nodekeys", nodekeys,
-		"votekeys", votekeys,
-		"identity", identity,
-		"comprehensiveSlotTracking", comprehensiveSlotTracking,
-		"monitorBlockSizes", monitorBlockSizes,
-	)
 	watcher := SlotWatcher{
-		client:                    client,
-		logger:                    logger,
-		nodekeys:                  nodekeys,
-		votekeys:                  votekeys,
-		identity:                  identity,
-		comprehensiveSlotTracking: comprehensiveSlotTracking,
-		monitorBlockSizes:         monitorBlockSizes,
-		lightMode:                 lightMode,
+		client: client,
+		logger: logger,
+		config: config,
 		// metrics:
 		TotalTransactionsMetric: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "solana_total_transactions",
@@ -182,11 +151,11 @@ func NewSlotWatcher(
 	return &watcher
 }
 
-func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
-	ticker := time.NewTicker(pace)
+func (c *SlotWatcher) WatchSlots(ctx context.Context) {
+	ticker := time.NewTicker(c.config.SlotPace)
 	defer ticker.Stop()
 
-	c.logger.Infof("Starting slot watcher, running every %v", pace)
+	c.logger.Infof("Starting slot watcher, running every %vs", c.config.SlotPace.Seconds())
 
 	for {
 		select {
@@ -210,7 +179,7 @@ func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
 
 			c.TotalTransactionsMetric.Set(float64(epochInfo.TransactionCount))
 			c.SlotHeightMetric.Set(float64(epochInfo.AbsoluteSlot))
-			c.BlockHeight.WithLabelValues(c.identity).Set(float64(epochInfo.BlockHeight))
+			c.BlockHeight.WithLabelValues(c.config.Identity).Set(float64(epochInfo.BlockHeight))
 
 			// if we get here, then the tracking numbers are set, so this is a "normal" run.
 			// start by checking if we have progressed since last run:
@@ -221,7 +190,7 @@ func (c *SlotWatcher) WatchSlots(ctx context.Context, pace time.Duration) {
 
 			if epochInfo.Epoch > c.currentEpoch {
 				// fetch inflation rewards for vote accounts:
-				if len(c.votekeys) > 0 {
+				if len(c.config.VoteKeys) > 0 {
 					err = c.fetchAndEmitInflationRewards(ctx, c.currentEpoch)
 					if err != nil {
 						c.logger.Errorf("Failed to emit inflation rewards, bailing out: %v", err)
@@ -283,7 +252,7 @@ func (c *SlotWatcher) trackEpoch(ctx context.Context, epoch *rpc.EpochInfo) {
 
 	// update leader schedule:
 	c.logger.Infof("Updating leader schedule for epoch %v ...", c.currentEpoch)
-	leaderSchedule, err := GetTrimmedLeaderSchedule(ctx, c.client, c.nodekeys, epoch.AbsoluteSlot, c.firstSlot)
+	leaderSchedule, err := GetTrimmedLeaderSchedule(ctx, c.client, c.config.NodeKeys, epoch.AbsoluteSlot, c.firstSlot)
 	if err != nil {
 		c.logger.Errorf("Failed to get trimmed leader schedule, bailing out: %v", err)
 	}
@@ -323,7 +292,7 @@ func (c *SlotWatcher) moveSlotWatermark(ctx context.Context, to int64) {
 // fetchAndEmitBlockProduction fetches block production up to the provided endSlot, emits the prometheus metrics,
 // and updates the SlotWatcher.slotWatermark accordingly
 func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot int64) {
-	if c.lightMode {
+	if c.config.LightMode {
 		c.logger.Debug("Skipping block-production fetching in light mode.")
 		return
 	}
@@ -351,7 +320,7 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 		c.LeaderSlotsMetric.WithLabelValues(StatusValid, address).Add(valid)
 		c.LeaderSlotsMetric.WithLabelValues(StatusSkipped, address).Add(skipped)
 
-		if slices.Contains(c.nodekeys, address) || c.comprehensiveSlotTracking {
+		if slices.Contains(c.config.NodeKeys, address) || c.config.ComprehensiveSlotTracking {
 			epochStr := toString(c.currentEpoch)
 			c.LeaderSlotsByEpochMetric.WithLabelValues(StatusValid, address, epochStr).Add(valid)
 			c.LeaderSlotsByEpochMetric.WithLabelValues(StatusSkipped, address, epochStr).Add(skipped)
@@ -364,7 +333,7 @@ func (c *SlotWatcher) fetchAndEmitBlockProduction(ctx context.Context, endSlot i
 // fetchAndEmitBlockInfos fetches and emits all the fee rewards (+ block sizes) for the tracked addresses between the
 // slotWatermark and endSlot
 func (c *SlotWatcher) fetchAndEmitBlockInfos(ctx context.Context, endSlot int64) {
-	if c.lightMode {
+	if c.config.LightMode {
 		c.logger.Debug("Skipping block-infos fetching in light mode.")
 		return
 	}
@@ -397,7 +366,7 @@ func (c *SlotWatcher) fetchAndEmitSingleBlockInfo(
 	ctx context.Context, identity string, epoch int64, slot int64,
 ) error {
 	var transactionDetails string
-	if c.monitorBlockSizes {
+	if c.config.MonitorBlockSizes {
 		transactionDetails = "accounts"
 	} else {
 		transactionDetails = "none"
@@ -430,7 +399,7 @@ func (c *SlotWatcher) fetchAndEmitSingleBlockInfo(
 	}
 
 	// track block size:
-	if c.monitorBlockSizes {
+	if c.config.MonitorBlockSizes {
 		c.BlockSizeMetric.WithLabelValues(identity).Set(float64(len(block.Transactions)))
 	}
 
@@ -440,18 +409,18 @@ func (c *SlotWatcher) fetchAndEmitSingleBlockInfo(
 // fetchAndEmitInflationRewards fetches and emits the inflation rewards for the configured inflationRewardAddresses
 // at the provided epoch
 func (c *SlotWatcher) fetchAndEmitInflationRewards(ctx context.Context, epoch int64) error {
-	if c.lightMode {
+	if c.config.LightMode {
 		c.logger.Debug("Skipping inflation-rewards fetching in light mode.")
 		return nil
 	}
 	c.logger.Infof("Fetching inflation reward for epoch %v ...", toString(epoch))
-	rewardInfos, err := c.client.GetInflationReward(ctx, rpc.CommitmentConfirmed, c.votekeys, &epoch, nil)
+	rewardInfos, err := c.client.GetInflationReward(ctx, rpc.CommitmentConfirmed, c.config.VoteKeys, &epoch, nil)
 	if err != nil {
 		return fmt.Errorf("error fetching inflation rewards: %w", err)
 	}
 
 	for i, rewardInfo := range rewardInfos {
-		address := c.votekeys[i]
+		address := c.config.VoteKeys[i]
 		reward := float64(rewardInfo.Amount) / float64(rpc.LamportsInSol)
 		c.InflationRewardsMetric.WithLabelValues(address, toString(epoch)).Set(reward)
 	}

--- a/cmd/solana_exporter/slots_test.go
+++ b/cmd/solana_exporter/slots_test.go
@@ -92,8 +92,8 @@ func TestSolanaCollector_WatchSlots_Static(t *testing.T) {
 	client := staticRPCClient{}
 	ctx, cancel := context.WithCancel(context.Background())
 	nodeIdentity, _ := client.GetIdentity(ctx)
-	collector := NewSolanaCollector(&client, 100*time.Millisecond, nil, identities, votekeys, nodeIdentity)
-	watcher := NewSlotWatcher(&client, identities, votekeys, nodeIdentity, false, false)
+	collector := NewSolanaCollector(&client, 100*time.Millisecond, nil, identities, votekeys, nodeIdentity, false)
+	watcher := NewSlotWatcher(&client, identities, votekeys, nodeIdentity, false, false, false)
 	// reset metrics before running tests:
 	watcher.LeaderSlotsMetric.Reset()
 	watcher.LeaderSlotsByEpochMetric.Reset()
@@ -163,8 +163,8 @@ func TestSolanaCollector_WatchSlots_Dynamic(t *testing.T) {
 	client := newDynamicRPCClient()
 	runCtx, runCancel := context.WithCancel(context.Background())
 	nodeIdentity, _ := client.GetIdentity(runCtx)
-	collector := NewSolanaCollector(client, 300*time.Millisecond, nil, identities, votekeys, nodeIdentity)
-	watcher := NewSlotWatcher(client, identities, votekeys, nodeIdentity, false, false)
+	collector := NewSolanaCollector(client, 300*time.Millisecond, nil, identities, votekeys, nodeIdentity, false)
+	watcher := NewSlotWatcher(client, identities, votekeys, nodeIdentity, false, false, false)
 	// reset metrics before running tests:
 	watcher.LeaderSlotsMetric.Reset()
 	watcher.LeaderSlotsByEpochMetric.Reset()


### PR DESCRIPTION
Added a light-mode config option that, when configured, makes the exporter only watch the metrics that can only be found from the node which it is querying.

Additionally, I also made the `SolanaCollector` and `SlotWatcher` use the `ExporterConfig` object directly, such that we don't have to pass around 100 variables all the time.

Closes #53